### PR TITLE
fix(migration): change payload and exception columns to longText in f…

### DIFF
--- a/publish/migrations/2024_02_16_192823_create_failed_messages_table.php
+++ b/publish/migrations/2024_02_16_192823_create_failed_messages_table.php
@@ -14,8 +14,8 @@ class CreateFailedMessagesTable extends Migration
         Schema::create('failed_messages', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->string('pool', 50)->index();
-            $table->text('payload');
-            $table->text('exception');
+            $table->longText('payload');
+            $table->longText('exception');
             $table->dateTime('failed_at')->index();
         });
     }


### PR DESCRIPTION
This pull request updates the failed_messages table migration by changing the column types for payload and exception from text to longText.